### PR TITLE
Add DATABASE_URL to auto-fix workflow

### DIFF
--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -13,6 +13,9 @@ jobs:
       issues: write
       pull-requests: write
 
+    env:
+      DATABASE_URL: file:./test.db
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds missing DATABASE_URL environment variable to the auto-fix-issue workflow to fix Prisma client generation error.