### PR TITLE
Run CI workflow manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   push:
     branches: [main, master]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Workaround until we fix the warp bot workflows, which currently don't trigger more workflows.